### PR TITLE
Fix lint warnings

### DIFF
--- a/packages/3box-ui-profiles/src/components/ProfileCardShowcase.jsx
+++ b/packages/3box-ui-profiles/src/components/ProfileCardShowcase.jsx
@@ -4,12 +4,12 @@
  */
 /* --- Global --- */
 import React from 'react'
-import {BoxInject} from '3box-ui-state'
+import { BoxInject } from '3box-ui-state'
 import { Authenticate } from '3box-ui-system'
-import {ProfileImage} from './ProfileImage'
-import {ProfileCover} from './ProfileCover'
-import {ProfileIdentity} from './ProfileIdentity'
-import {ProfileDetailsOccupation} from './ProfileDetailsOccupation'
+import { ProfileImage } from './ProfileImage'
+import { ProfileCover } from './ProfileCover'
+import { ProfileIdentity } from './ProfileIdentity'
+import { ProfileDetailsOccupation } from './ProfileDetailsOccupation'
 
 const styles = {
   container: {
@@ -17,18 +17,18 @@ const styles = {
     minHeight: 100,
     p: 6
   },
-    cover: {
-      bg: 'blue', 
-      borderRadius: '10px 10px 0 0',
-      opacity: 0.2,
-      minHeight: 100
-    },
-    avatar: {
-      mb: 2,
-      mt: -60,
-      height: 70, 
-      width: 70, 
-    },
+  cover: {
+    bg: 'blue',
+    borderRadius: '10px 10px 0 0',
+    opacity: 0.2,
+    minHeight: 100
+  },
+  avatar: {
+    mb: 2,
+    mt: -60,
+    height: 70,
+    width: 70,
+  },
   main: {
     bg: 'neutral',
     borderRadius: '0 0 10px 10px',
@@ -36,24 +36,23 @@ const styles = {
     borderColor: 'borderShadow',
     boxShadow: 0,
     color: 'text',
-    color: 'text',
     p: 3
   }
 }
 
 /* --- Component --- */
 const ProfileCardShowcaseView = ({ box, children, ...props }) =>
-<Atom.Flex center column sx={styles.container}>
-  <ProfileCover sx={styles.cover}/>
-  <Atom.Flex center column sx={styles.main}>
-    <ProfileImage variant='avatar' sx={styles.avatar} />
-    <ProfileIdentity />
-    <ProfileDetailsOccupation sx={{fontSize: 1, fontWeight: 300}} />
-    <Authenticate />
+  <Atom.Flex center column sx={styles.container}>
+    <ProfileCover sx={styles.cover} />
+    <Atom.Flex center column sx={styles.main}>
+      <ProfileImage variant='avatar' sx={styles.avatar} />
+      <ProfileIdentity />
+      <ProfileDetailsOccupation sx={{ fontSize: 1, fontWeight: 300 }} />
+      <Authenticate />
+    </Atom.Flex>
+
   </Atom.Flex>
 
-</Atom.Flex>
 
 
-
-export const ProfileCardShowcase = props =><BoxInject><ProfileCardShowcaseView {...props} /></BoxInject>
+export const ProfileCardShowcase = props => <BoxInject><ProfileCardShowcaseView {...props} /></BoxInject>

--- a/packages/3box-ui-profiles/src/components/ProfileCardVanity.jsx
+++ b/packages/3box-ui-profiles/src/components/ProfileCardVanity.jsx
@@ -4,30 +4,30 @@
  */
 /* --- Global --- */
 import React from 'react'
-import {BoxInject} from '3box-ui-state'
+import { BoxInject } from '3box-ui-state'
 import { Authenticate } from '3box-ui-system'
-import {ProfileImage} from './ProfileImage'
-import {ProfileCover} from './ProfileCover'
-import {ProfileIdentity} from './ProfileIdentity'
-import {ProfileDetailsOccupation} from './ProfileDetailsOccupation'
+import { ProfileImage } from './ProfileImage'
+import { ProfileCover } from './ProfileCover'
+import { ProfileIdentity } from './ProfileIdentity'
+import { ProfileDetailsOccupation } from './ProfileDetailsOccupation'
 
 const styles = {
   header: {
-    bg: 'night', 
+    bg: 'night',
     borderRadius: '10px 10px 0 0',
     minHeight: 100
   },
-    cover: {
-      bg: 'blue', 
-      borderRadius: '10px 10px 0 0',
-      minHeight: 100
-    },
-    avatar: {
-      height: 80, 
-      mb: 2,
-      mt: -60,
-      width: 80, 
-    },
+  cover: {
+    bg: 'blue',
+    borderRadius: '10px 10px 0 0',
+    minHeight: 100
+  },
+  avatar: {
+    height: 80,
+    mb: 2,
+    mt: -60,
+    width: 80,
+  },
   main: {
     bg: 'neutral',
     borderRadius: '0 0 10px 10px',
@@ -35,26 +35,25 @@ const styles = {
     borderColor: 'borderShadow',
     boxShadow: 0,
     color: 'text',
-    color: 'text',
     p: 3
   }
 }
 
 /* --- Component --- */
 const ProfileCardVanityView = ({ box, children, ...props }) =>
-<Atom.Box>
+  <Atom.Box>
 
-  <Atom.Box sx={styles.header}>
-    <ProfileCover sx={styles.cover}/>
+    <Atom.Box sx={styles.header}>
+      <ProfileCover sx={styles.cover} />
+    </Atom.Box>
+
+    <Atom.Flex center column sx={styles.main}>
+      <ProfileImage variant='avatar' sx={styles.avatar} />
+      <ProfileIdentity />
+      <ProfileDetailsOccupation sx={{ fontSize: 1, fontWeight: 300 }} />
+      <Authenticate />
+    </Atom.Flex>
   </Atom.Box>
 
-  <Atom.Flex center column sx={styles.main}>
-    <ProfileImage variant='avatar' sx={styles.avatar} />
-    <ProfileIdentity />
-    <ProfileDetailsOccupation sx={{fontSize: 1, fontWeight: 300}} />
-    <Authenticate />
-  </Atom.Flex>
-</Atom.Box>
 
-
-export const ProfileCardVanity = props =><BoxInject><ProfileCardVanityView {...props} /></BoxInject>
+export const ProfileCardVanity = props => <BoxInject><ProfileCardVanityView {...props} /></BoxInject>

--- a/packages/3box-ui-state/src/reducer.js
+++ b/packages/3box-ui-state/src/reducer.js
@@ -57,7 +57,7 @@ export default (state, action) => {
 				.set(
 					`store.profiles`,
 					state.store.profiles.filter(
-						i => i.payload == action.address
+						i => i.payload === action.address
 					)
 				)
 				.set(`@.${action.address}.profile`, action.payload)

--- a/packages/3box-ui-state/src/requests/useThreadPost.js
+++ b/packages/3box-ui-state/src/requests/useThreadPost.js
@@ -44,7 +44,7 @@ export const useThreadPost = (state, dispatch) => {
 								if (postSelected.postId) {
 									const thread =
 										state.auth.threads[
-											postSelected.threadName
+										postSelected.threadName
 										];
 									await state.auth.threads[
 										postSelected.threadName
@@ -64,7 +64,6 @@ export const useThreadPost = (state, dispatch) => {
 										type: 'THREAD_POST_DELETE_FAILURE',
 										threadName: postSelected.threadName,
 										space: postSelected.space,
-										threadName: postSelected.threadName,
 										firstModerator: box.address
 									});
 								}

--- a/packages/3box-ui-system/src/api/ProfileSmall.jsx
+++ b/packages/3box-ui-system/src/api/ProfileSmall.jsx
@@ -8,69 +8,70 @@ import { GenerateImage } from './utilities'
 
 /* ------- Component ------- */
 const BoxProfileRetrieve = ({ box, address, small, styled, ...props }) => {
-  const [ isNameDisabled, setIsNameDisabled ] = useState(props.disableName)
-  const [ profile, setProfile ] = useState()
+  const [isNameDisabled, setIsNameDisabled] = useState(props.disableName)
+  const [profile, setProfile] = useState()
   /**
    * @function ProfileRetrieve
    * @description Send message signing request to current Web3 provider.
    */
-  useEffect( () => {
-    if(address && !profile) {
+  useEffect(() => {
+    if (address && !profile) {
       box.getProfileRequest(address)
-    } else if(idx(box, _=>_.profiles[address])) {
+    } else if (idx(box, _ => _.profiles[address])) {
       // setProfile(idx(box, _=>_.profiles[address]))
     }
-  }, [ address, profile])
-  
-  useEffect( () => {
-    if(!profile) {
-      setProfile(idx(box, _=>_.profiles[address]))
-    } 
-  }, [ profile, idx(box, _=>_.profiles[address])])
+  }, [address, profile])
+
+  useEffect(() => {
+    if (!profile) {
+      setProfile(idx(box, _ => _.profiles[address]))
+    }
+  }, [profile, idx(box, _ => _.profiles[address])])
 
 
   return (
     <ProfileCard small={small} profile={profile} address={address} {...props} />
-)}
+  )
+}
 
-const ProfileCard = ({ profile, small, ...props}) => {
-  const [ isNameDisabled, setIsNameDisabled ] = useState(props.disableName)
+const ProfileCard = ({ profile, small, ...props }) => {
+  const [isNameDisabled, setIsNameDisabled] = useState(props.disableName)
   return (
     profile
-    ?<>
-      <Flex alignCenter>
-        <Flex
-          circle center column boxShadow={0} p={2}
-          border="1px solid #FFF"
-          overflow='hidden'
-          m={1}
-          width={24} height={24} maxWidth={26} maxWidth={26}
+      ? <>
+        <Flex alignCenter>
+          <Flex
+            circle center column boxShadow={0} p={2}
+            border="1px solid #FFF"
+            overflow='hidden'
+            m={1}
+            width={24} height={24} maxWidth={26}
           >
             {
               profile.image
-              ? <BackgroundImage
-                ratio={.5}
-                src={GenerateImage(profile.image)} />
-              : <BackgroundImage
-                ratio={.5}
-                src='https://images.assetsdelivery.com/compings_v2/mingirov/mingirov1904/mingirov190400568.jpg' /> 
+                ? <BackgroundImage
+                  ratio={.5}
+                  src={GenerateImage(profile.image)} />
+                : <BackgroundImage
+                  ratio={.5}
+                  src='https://images.assetsdelivery.com/compings_v2/mingirov/mingirov1904/mingirov190400568.jpg' />
             }
-        </Flex>
-          
+          </Flex>
+
           {
-          !isNameDisabled &&
+            !isNameDisabled &&
             <Box ml={10}>
               <Link to={`/profile/${props.address}`}>
                 <Heading md noMargin>
-                  {idx(profile, _=>_.name)}
+                  {idx(profile, _ => _.name)}
                 </Heading>
               </Link>
             </Box>
           }
-      </Flex>
-    </>
-    : <Flex alignCenter>
-        <Span><Image card circle src='https://static.thenounproject.com/png/2348501-200.png' border='none' bg='white' p={0} width={20}/></Span>
+        </Flex>
+      </>
+      : <Flex alignCenter>
+        <Span><Image card circle src='https://static.thenounproject.com/png/2348501-200.png' border='none' bg='white' p={0} width={20} /></Span>
         <Box ml={10}>
           <Box borderRadius={40} bg='gray' p={1} width={120} />
         </Box>
@@ -79,6 +80,6 @@ const ProfileCard = ({ profile, small, ...props}) => {
 }
 
 export default props =>
-<BoxInject>
-  <BoxProfileRetrieve {...props} />
-</BoxInject>
+  <BoxInject>
+    <BoxProfileRetrieve {...props} />
+  </BoxInject>

--- a/packages/3box-ui-system/src/api/component.jsx
+++ b/packages/3box-ui-system/src/api/component.jsx
@@ -1,20 +1,20 @@
 export function isClassComponent(component) {
     return (
-        typeof component === 'export function' && 
+        typeof component === 'function' &&
         !!component.prototype.isReactComponent
     ) ? true : false
 }
 
 export function isFunctionComponent(component) {
     return (
-        typeof component === 'export function' && 
+        typeof component === 'function' &&
         String(component).includes('return React.createElement')
     ) ? true : false;
 }
 
 export function isReactComponent(component) {
     return (
-        isClassComponent(component) || 
+        isClassComponent(component) ||
         isFunctionComponent(component)
     ) ? true : false;
 }
@@ -28,12 +28,12 @@ export function isDOMTypeElement(element) {
 }
 
 export function isCompositeTypeElement(element) {
-    return isElement(element) && typeof element.type === 'export function';
+    return isElement(element) && typeof element.type === 'function';
 }
 
 export const Component = component =>
-isReactComponent(component)
-    ? component
-    : isElement(component)
-      ? React.cloneElement(component)
-      : null
+    isReactComponent(component)
+        ? component
+        : isElement(component)
+            ? React.cloneElement(component)
+            : null

--- a/packages/3box-ui-system/src/components/BoxLoginButton.jsx
+++ b/packages/3box-ui-system/src/components/BoxLoginButton.jsx
@@ -31,7 +31,7 @@ const BoxLoginButton = ({ box, isMenuAvailable, styled, children, ...props }) =>
           <Box>
             <Image maxWidth={36} mx={2} src='https://metamask.io/img/metamask.png' />
           </Box>
-          <a href='https://metamask.io/' target='_blank'>
+          <a href='https://metamask.io/' target='_blank' rel='noopener noreferrer'>
             <Span>Install MetaMask to Enable</Span>
           </a>
         </Flex>

--- a/packages/3box-ui-system/src/components/BoxProfileRetrieve.jsx
+++ b/packages/3box-ui-system/src/components/BoxProfileRetrieve.jsx
@@ -8,64 +8,65 @@ import { GenerateImage } from './utilities'
 
 /* ------- Component ------- */
 const BoxProfileRetrieve = ({ box, address, small, styled, ...props }) => {
-  const [ profile, setProfile ] = useState()
+  const [profile, setProfile] = useState()
   /**
    * @function ProfileRetrieve
    * @description Send message signing request to current Web3 provider.
    */
-  useEffect( () => {
-    if(address && !profile) {
+  useEffect(() => {
+    if (address && !profile) {
       box.getProfileRequest(address)
-    } else if(idx(box, _=>_.profiles[address])) {
+    } else if (idx(box, _ => _.profiles[address])) {
       // setProfile(idx(box, _=>_.profiles[address]))
     }
-  }, [ address, profile])
-  
-  useEffect( () => {
-    if(!profile) {
-      setProfile(idx(box, _=>_.profiles[address]))
-    } 
-  }, [ profile, idx(box, _=>_.profiles[address])])
+  }, [address, profile])
+
+  useEffect(() => {
+    if (!profile) {
+      setProfile(idx(box, _ => _.profiles[address]))
+    }
+  }, [profile, idx(box, _ => _.profiles[address])])
 
 
   return (
     <ProfileCard small={small} profile={profile} address={address} />
-)}
+  )
+}
 
-const ProfileCard = ({ profile, small, ...props}) => {
+const ProfileCard = ({ profile, small, ...props }) => {
   return (
     profile
-    ?<>
-      <Flex alignCenter>
-        <Flex
-          circle center column boxShadow={0} p={2}
-          border="2px solid #FFF"
-          overflow='hidden'
-          width={48} height={48} maxWidth={48} maxWidth={48}
+      ? <>
+        <Flex alignCenter>
+          <Flex
+            circle center column boxShadow={0} p={2}
+            border="2px solid #FFF"
+            overflow='hidden'
+            width={48} height={48} maxWidth={48}
           >
             {
               profile.image
-              ? <BackgroundImage
-                ratio={.5}
-                src={GenerateImage(profile.image)} />
-              : <BackgroundImage
-                ratio={.5}
-                src='https://images.assetsdelivery.com/compings_v2/mingirov/mingirov1904/mingirov190400568.jpg' /> 
+                ? <BackgroundImage
+                  ratio={.5}
+                  src={GenerateImage(profile.image)} />
+                : <BackgroundImage
+                  ratio={.5}
+                  src='https://images.assetsdelivery.com/compings_v2/mingirov/mingirov1904/mingirov190400568.jpg' />
             }
-        </Flex>
+          </Flex>
 
-        <Box ml={10}>
-          <Link to={`/profile/${props.address}`}>
-            <Heading md heavy noMargin>
-              {idx(profile, _=>_.name)}
-            </Heading>
-          </Link>
-          <Heading sm thin noMargin level={4}>{idx(profile, _=>_.job)}</Heading>
-        </Box>
-      </Flex>
-    </>
-    : <Flex alignCenter>
-        <Span><Image card circle src='https://static.thenounproject.com/png/2348501-200.png' border='none' bg='white' width={48}/></Span>
+          <Box ml={10}>
+            <Link to={`/profile/${props.address}`}>
+              <Heading md heavy noMargin>
+                {idx(profile, _ => _.name)}
+              </Heading>
+            </Link>
+            <Heading sm thin noMargin level={4}>{idx(profile, _ => _.job)}</Heading>
+          </Box>
+        </Flex>
+      </>
+      : <Flex alignCenter>
+        <Span><Image card circle src='https://static.thenounproject.com/png/2348501-200.png' border='none' bg='white' width={48} /></Span>
         <Box ml={10}>
           <Box borderRadius={40} bg='gray' p={2} width={160} />
           <Box borderRadius={40} bg='gray' p={1} width={80} mt={10} />
@@ -75,6 +76,6 @@ const ProfileCard = ({ profile, small, ...props}) => {
 }
 
 export default props =>
-<BoxInject>
-  <BoxProfileRetrieve {...props} />
-</BoxInject>
+  <BoxInject>
+    <BoxProfileRetrieve {...props} />
+  </BoxInject>

--- a/packages/design-system-atoms/src/Box.jsx
+++ b/packages/design-system-atoms/src/Box.jsx
@@ -1,10 +1,10 @@
-import {useEffect, useState, useContext} from 'react';
+import { useEffect, useState, useContext } from 'react';
 import styled from '@emotion/styled';
-import css, {get} from '@styled-system/css';
-import {createShouldForwardProp} from '@styled-system/should-forward-prop';
+import css, { get } from '@styled-system/css';
+import { createShouldForwardProp } from '@styled-system/should-forward-prop';
 import space from '@styled-system/space';
 import color from '@styled-system/color';
-import {Context} from 'theme-ui';
+import { Context } from 'theme-ui';
 
 export const useGradientEffect = props => {
   const theme = useContext(Context);
@@ -14,7 +14,7 @@ export const useGradientEffect = props => {
       setGradient(
         `linear-gradient(180deg , ${theme.gradients[props.gradient]}`,
       );
-  }, [props.gradient]);
+  }, [props.gradient, theme.gradients]);
 
   return gradient;
 };
@@ -27,21 +27,21 @@ const shouldForwardProp = createShouldForwardProp([
 const sx = props => css(props.sx)(props.theme);
 const base = props => css(props.__css)(props.theme);
 
-const variant = ({theme, variant, __themeKey = 'variants'}) =>
+const variant = ({ theme, variant, __themeKey = 'variants' }) =>
   css(get(theme, __themeKey + '.' + variant, get(theme, variant)));
 
-const shorthand = ({theme, ...props}) =>
+const shorthand = ({ theme, ...props }) =>
   Object.keys(props).map(selector =>
     css(get(theme, `effects.common.${selector}`)),
   );
 
-const variants = ({theme, variants, __variantsKey = 'variants'}) =>
+const variants = ({ theme, variants, __variantsKey = 'variants' }) =>
   Array.isArray(variants)
     ? variants.map(variant =>
-        css(get(theme, __variantsKey + '.' + variant, get(theme, variant))),
-      )
+      css(get(theme, __variantsKey + '.' + variant, get(theme, variant))),
+    )
     : null;
-const variantsShorthand = ({theme, __effectKey = 'common', ...props}) =>
+const variantsShorthand = ({ theme, __effectKey = 'common', ...props }) =>
   Object.keys(props).map(selector =>
     css(get(theme, `effects.${__effectKey}.${selector}`)),
   );
@@ -58,11 +58,11 @@ const gradient = ({
   });
 };
 
-const effects = ({theme, effects, __effectKey = 'effects'}) =>
+const effects = ({ theme, effects, __effectKey = 'effects' }) =>
   Array.isArray(effects)
     ? effects.map(effect =>
-        css(get(theme, __effectKey + '.' + effect, get(theme, effect))),
-      )
+      css(get(theme, __effectKey + '.' + effect, get(theme, effect))),
+    )
     : null;
 
 export const Box = styled('div', {

--- a/packages/design-system-molecules/src/Card/HeaderDefault.jsx
+++ b/packages/design-system-molecules/src/Card/HeaderDefault.jsx
@@ -4,7 +4,7 @@
  */
 /* eslint-disable react-hooks/exhaustive-deps */
 import React from 'react'
-import { Blockquote, Container, BackgroundGradient, BackgroundImage, Flex, Heading, Span} from '@horizin/design-system-atoms'
+import { BackgroundImage, Flex } from '@horizin/design-system-atoms'
 
 const FooterDefault = props => {
 

--- a/packages/design-system-molecules/src/Card/HeaderShowcase.jsx
+++ b/packages/design-system-molecules/src/Card/HeaderShowcase.jsx
@@ -4,7 +4,7 @@
  */
 /* eslint-disable react-hooks/exhaustive-deps */
 import React from 'react'
-import { Blockquote, Container, BackgroundGradient, BackgroundImage, Flex, Heading, Span} from '@horizin/design-system-atoms'
+import { BackgroundImage } from '@horizin/design-system-atoms'
 
 const FooterDefault = props => {
 

--- a/packages/design-system-molecules/src/Card/MainDefault.jsx
+++ b/packages/design-system-molecules/src/Card/MainDefault.jsx
@@ -4,20 +4,20 @@
  */
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, useState } from 'react'
-import PropTypes from 'prop-types'
-import { Image, Box, Text, Flex, Heading, Span} from '@horizin/design-system-atoms'
+// import PropTypes from 'prop-types'
+import { Image, Box, Text, Flex, Heading, Span } from '@horizin/design-system-atoms'
 import { Link } from '@horizin/design-system-molecules'
 
 const ComponentMainDefault = props => {
   const [sxMain, setSXMain] = useState({ ...props.sxMain })
 
-  const [sxTitle, setSXTitle] = useState({ fontSize: 3, fontWeight: 500, ...props.sxTitle })
-  const [sxTagline, setSXTagline] = useState({ fontSize: 2, fontWeight: 400, ...props.sxTagline })
+  const [sxTitle] = useState({ fontSize: 3, fontWeight: 500, ...props.sxTitle })
+  const [sxTagline] = useState({ fontSize: 2, fontWeight: 400, ...props.sxTagline })
   const [sxImage, setSXImage] = useState({ ...props.sxImage })
 
   const [sxImageWrap, setSXImageWrap] = useState({ ...props.sxImageWrap })
-  const [sxContent, setSXContent] = useState({ fontSize: 1, ...props.sxContent })
-  const [sxSummary, setSXSummary] = useState({ fontSize: 1, ...props.sxSummary })
+  const [sxContent] = useState({ fontSize: 1, ...props.sxContent })
+  const [sxSummary] = useState({ fontSize: 1, ...props.sxSummary })
 
   /**
    * @name Global

--- a/packages/design-system-molecules/src/Card/effects.jsx
+++ b/packages/design-system-molecules/src/Card/effects.jsx
@@ -4,7 +4,7 @@
  */
 /* eslint-disable react-hooks/exhaustive-deps */
 import React from 'react'
-import PropTypes from 'prop-types'
+// import PropTypes from 'prop-types'
 import { useState, useEffect } from 'react'
 
 /* --- Module --- */
@@ -12,7 +12,7 @@ import HeaderDefault from './HeaderDefault'
 import HeaderShowcase from './HeaderShowcase'
 
 import MainDefault from './MainDefault'
-import MainShowcase from './MainShowcase'
+// import MainShowcase from './MainShowcase'
 import FooterDefault from './FooterDefault'
 
 export const useMainRenderEffect = (props) => {

--- a/packages/design-system-molecules/src/Card/index.jsx
+++ b/packages/design-system-molecules/src/Card/index.jsx
@@ -5,7 +5,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
-import { Flex} from '@horizin/design-system-atoms'
+import { Flex } from '@horizin/design-system-atoms'
 
 import { useCardEffect } from '../effects'
 
@@ -14,8 +14,8 @@ import { useMainRenderEffect } from './effects'
 
 const Card = ({ as, children, ...props }) => {
   const card = useCardEffect(props)
+  const [sx] = useState({ ...props.sx })
 
-  const [sx, setSX] = useState({ ...props.sx })
   let render
   render = useMainRenderEffect(props)
 
@@ -42,7 +42,7 @@ const Card = ({ as, children, ...props }) => {
     <Flex column sx={{
       ...card,
       ...sx
-      }}>
+    }}>
       {/* Main */}
       {render.header}
 
@@ -77,11 +77,11 @@ Card.propTypes = {
   sxHeader: PropTypes.object,        // ui-theme Header
   sxMain: PropTypes.object,          // ui-theme Main
   sxFooter: PropTypes.object,        // ui-theme Footer
-  sxTitle:  PropTypes.object,        // ui-theme Title
-  sxTagline:  PropTypes.object,      // ui-theme Title
-  sxContent:  PropTypes.object,      // ui-theme Title
-  sxSummary:  PropTypes.object,      // ui-theme Title
-  sxTags:  PropTypes.object,         // ui-theme Title
+  sxTitle: PropTypes.object,        // ui-theme Title
+  sxTagline: PropTypes.object,      // ui-theme Title
+  sxContent: PropTypes.object,      // ui-theme Title
+  sxSummary: PropTypes.object,      // ui-theme Title
+  sxTags: PropTypes.object,         // ui-theme Title
 }
 
 Card.defaultProps = {

--- a/packages/design-system-molecules/src/Link/index.jsx
+++ b/packages/design-system-molecules/src/Link/index.jsx
@@ -1,13 +1,13 @@
 /** @jsx jsx */
-import {jsx} from 'theme-ui';
-import {Link} from '@reach/router';
+import { jsx } from 'theme-ui';
+import { Link } from '@reach/router';
 
-import {useFontSizeEffect, useFontWeightEffect, useTagEffect} from '../effects';
+// import { useFontSizeEffect, useFontWeightEffect, useTagEffect } from '../effects';
 
-export default ({sx, ...props}) => {
-  const size = useFontSizeEffect(props);
-  const weight = useFontWeightEffect(props);
-  const tag = useTagEffect(props);
+export default ({ sx, ...props }) => {
+  // const size = useFontSizeEffect(props);
+  // const weight = useFontWeightEffect(props);
+  // const tag = useTagEffect(props);
 
   return (
     <Link

--- a/packages/design-system-molecules/src/Showcase/index.jsx
+++ b/packages/design-system-molecules/src/Showcase/index.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React from 'react'
-import { Blockquote, Container, BackgroundGradient, BackgroundImage, Flex, Heading, Span} from '@horizin/design-system-atoms'
+import { Blockquote, Container, BackgroundGradient, BackgroundImage, Flex, Heading } from '@horizin/design-system-atoms'
 
 const Showcase = ({ as, sx, children, ...props }) =>
   <>

--- a/packages/design-system-molecules/src/Slides.jsx
+++ b/packages/design-system-molecules/src/Slides.jsx
@@ -1,7 +1,7 @@
-import React, {useEffect, useState} from 'react';
-import {useRef} from 'react';
+import React, { useEffect, useState } from 'react';
+import { useRef } from 'react';
 import useComponentSize from '@rehooks/component-size';
-import {Component} from '@horizin/ui-compose';
+import { Component } from '@horizin/ui-compose';
 import {
   CarouselProvider,
   Slider,
@@ -13,8 +13,8 @@ import {
   ButtonNext,
 } from 'pure-react-carousel';
 import 'pure-react-carousel/dist/react-carousel.es.css';
-import {Flex} from '@horizin/design-system-atoms';
-export const Slides = ({children, ...props}) => {
+import { Flex } from '@horizin/design-system-atoms';
+export const Slides = ({ children, ...props }) => {
   const [width, setWidth] = useState(props.naturalSlideHeight);
   const [height, setHeight] = useState(props.naturalSlideHeight);
 
@@ -37,7 +37,7 @@ export const Slides = ({children, ...props}) => {
             </Slide>
           ))}
       </Slider>
-      <Flex center column sx={{my: 3}}>
+      <Flex center column sx={{ my: 3 }}>
         <Flex>
           <ButtonFirst>First</ButtonFirst>
           <ButtonBack>Back</ButtonBack>
@@ -50,7 +50,7 @@ export const Slides = ({children, ...props}) => {
   );
 };
 
-const ComponentResize = ({item, setHeight, setWidth}) => {
+const ComponentResize = ({ item, setHeight, setWidth }) => {
   let ref = useRef(null);
   let size = useComponentSize(ref);
 
@@ -60,6 +60,6 @@ const ComponentResize = ({item, setHeight, setWidth}) => {
       setWidth(size.width);
     }
     console.log(size, 'sizesize');
-  }, [size]);
-  return <Flex>{Component(item, {ref: ref})}</Flex>;
+  }, [size, setHeight, setWidth]);
+  return <Flex>{Component(item, { ref: ref })}</Flex>;
 };

--- a/packages/design-system-organisms/src/Paginator/index.jsx
+++ b/packages/design-system-organisms/src/Paginator/index.jsx
@@ -1,26 +1,26 @@
 import React, { useState, useEffect } from 'react';
-import PaginatorHooked from 'react-hooks-paginator';
- 
+// import PaginatorHooked from 'react-hooks-paginator';
+
 const Paginator = props => {
-  const pageLimit = 10;
- 
-  const [offset, setOffset] = useState(0);
-  const [currentPage, setCurrentPage] = useState(1);
+  // const pageLimit = 10;
+
+  // const [offset, setOffset] = useState(0);
+  // const [currentPage, setCurrentPage] = useState(1);
   const [data, setData] = useState([]);
-  const [currentData, setCurrentData] = useState([]);
- 
+  const [currentData] = useState([]);
+
   useEffect(() => {
-    if(data.length = 0) {
+    if (data.length === 0) {
       setData([
         'data',
       ])
     }
-  }, [props]);
- 
+  }, [data.length]);
+
   // useEffect(() => {
   //   setCurrentData(data.slice(offset, offset + pageLimit));
   // }, [offset, data]);
- 
+
   return (
     <div>
       <ul>
@@ -39,5 +39,5 @@ const Paginator = props => {
     </div>
   );
 }
- 
+
 export default Paginator

--- a/packages/design-system-organisms/src/ToastOpen/index.jsx
+++ b/packages/design-system-organisms/src/ToastOpen/index.jsx
@@ -2,18 +2,19 @@
 import React, { useEffect, useState } from "react";
 import { PortalContext } from 'react-portal-system'
 
-const ToastOpen = ({ portal, content, closeTimer, closeOnClick, label, id, sx, ...props}) => { 
-  const [ isOpen, setOpen ] = useState(props.open)
-  useEffect( () => { 
-    if(isOpen) 
+const ToastOpen = ({ portal, content, closeTimer, closeOnClick, label, id, sx, ...props }) => {
+  const [isOpen, setOpen] = useState(props.open)
+  useEffect(() => {
+    if (isOpen)
       portal.openToast({ content, closeTimer, closeOnClick, label, id, sx })
-  }, [isOpen])
+  }, [isOpen, portal, content, closeTimer, closeOnClick, label, id, sx])
 
-  useEffect( () => { 
+  useEffect(() => {
     setOpen(props.open)
-  }, props.open)
+  }, [props.open])
 
-  return(null)}
+  return (null)
+}
 
 export default ({
   ...props

--- a/packages/react-portal-system/src/components/PortalTypes.jsx
+++ b/packages/react-portal-system/src/components/PortalTypes.jsx
@@ -28,14 +28,14 @@ const Component = ({
         <BackgroundGradient bg='black' fixed={true} absolute={false} opacity={.25} onClick={close} />
 
         {
-          position == 'toast'
+          position === 'toast'
           && <Box card noPadding maxWidth={200} layout={positionStyle || layoutDefault || position} {...styledModal}>
             <div>
               {
                 label &&
                 <Flex alignCenter between gradient='blue' color='white' p={10} fullWidth>
                   <Span fontSize={[3]}>{label}</Span>
-                  <Span pointer sm heavy pointer onClick={close}>X</Span>
+                  <Span pointer sm heavy onClick={close}>X</Span>
                 </Flex>
               }
               <Box p={10}>
@@ -49,14 +49,14 @@ const Component = ({
           </Box>
         }
         {
-          position == 'panel'
+          position === 'panel'
           && <Box card noPadding height='100%' layout={positionStyle || position} {...styledModal}>
             <div>
               {
                 label &&
                 <Flex alignCenter between gradient='blue' color='white' p={10} fullWidth>
                   <Span fontSize={[3]}>{label}</Span>
-                  <Span pointer sm heavy pointer onClick={close}>X</Span>
+                  <Span pointer sm heavy onClick={close}>X</Span>
                 </Flex>
               }
               <Box p={20}>
@@ -78,7 +78,7 @@ const Component = ({
               label &&
               <Flex alignCenter borderRoundedTop between gradient='blue' color='white' p={10} fullWidth>
                 <Span fontSize={[3]}>{label}</Span>
-                <Span pointer sm heavy pointer onClick={close}>X</Span>
+                <Span pointer sm heavy onClick={close}>X</Span>
               </Flex>
             }
             <Box bg='white' card borderCurvedBottom>

--- a/packages/react-portal-system/src/components/styled/Modal.jsx
+++ b/packages/react-portal-system/src/components/styled/Modal.jsx
@@ -71,7 +71,7 @@ const ModalActions = ({
                 {...styledLabel}
               >
                 <Span fontSize={[3]}>{label}</Span>
-                <Span pointer md heavy pointer onClick={() => closeHandler()}>
+                <Span pointer md heavy onClick={() => closeHandler()}>
                   X
                 </Span>
               </Flex>

--- a/packages/react-portal-system/src/components/styled/Panel.jsx
+++ b/packages/react-portal-system/src/components/styled/Panel.jsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react'
-import { Box, Flex, Span, Absolute, Fixed } from '@horizin/design-system-atoms'
+import { Box, Flex, Span, Fixed } from '@horizin/design-system-atoms'
 import { CSSTransition } from 'react-transition-group';
 
 const PanelActions = ({ portal, label, content, styled, styledLabel, id, ...props }) => {
-  const [ style, setStyle ] = useState({
+  const [style, setStyle] = useState({
     bg: 'white',
     boxShadow: 0,
     p: 10,
@@ -33,7 +33,7 @@ const PanelActions = ({ portal, label, content, styled, styledLabel, id, ...prop
   return (
     <>
       <CSSTransition in={(isAnimating)} timeout={300} classNames="fadeIn">
-        <Fixed sx={{bg: 'night', opacity: 0.2, zIndex: 90}} fillContainer onClick={closeHandler} />
+        <Fixed sx={{ bg: 'night', opacity: 0.2, zIndex: 90 }} fillContainer onClick={closeHandler} />
       </CSSTransition>
 
       <CSSTransition in={(isAnimating)} timeout={300} classNames="fadeInLeft">
@@ -44,7 +44,7 @@ const PanelActions = ({ portal, label, content, styled, styledLabel, id, ...prop
                 label &&
                 <Flex alignCenter between fullWidth gradient='gray' p={10} {...styledLabel}>
                   <Span fontSize={[3]}>{label}</Span>
-                  <Span pointer md heavy pointer onClick={closeHandler}>X</Span>
+                  <Span pointer md heavy onClick={closeHandler}>X</Span>
                 </Flex>
               }
               <Box>

--- a/packages/react-portal-system/src/reducer.js
+++ b/packages/react-portal-system/src/reducer.js
@@ -15,7 +15,6 @@ const reducerActions = (state, action) => {
               [instance]: toasts,
             }
           }
-          break;
 
         default:
           return {

--- a/packages/ui-compose/src/Component/index.jsx
+++ b/packages/ui-compose/src/Component/index.jsx
@@ -1,13 +1,14 @@
 export function isClassComponent(component) {
-    console.log('isClassComponent >>', typeof component)
-    return (
-        typeof component === 'export function' &&
-        !!component.prototype.isReactComponent
-    ) ? true : false
+    if (component.prototype) {
+        return (
+            typeof component === 'function' &&
+            !!component.prototype.isReactComponent
+        )
+    }
+    return false
 }
 
 export function isInlineFunctionComponent(component) {
-    console.log('isInlineFunctionComponent >>', typeof component)
     return (
         typeof component === 'function' &&
         String(component).includes('createElement')
@@ -15,9 +16,8 @@ export function isInlineFunctionComponent(component) {
 }
 
 export function isFunctionComponent(component) {
-    console.log('isFunctionComponent >>', typeof component)
     return (
-        typeof component === 'export function' &&
+        typeof component === 'function' &&
         String(component).includes('return React.createElement')
     ) ? true : false;
 }
@@ -39,7 +39,7 @@ export function isDOMTypeElement(element) {
 }
 
 export function isCompositeTypeElement(element) {
-    return isElement(element) && typeof element.type === 'export function';
+    return isElement(element) && typeof element.type === 'function';
 }
 
 export default (component, props) => (

--- a/packages/ui-compose/src/Component/index.jsx
+++ b/packages/ui-compose/src/Component/index.jsx
@@ -1,4 +1,5 @@
 export function isClassComponent(component) {
+    console.log('isClassComponent >>', typeof component)
     return (
         typeof component === 'export function' &&
         !!component.prototype.isReactComponent
@@ -6,6 +7,7 @@ export function isClassComponent(component) {
 }
 
 export function isInlineFunctionComponent(component) {
+    console.log('isInlineFunctionComponent >>', typeof component)
     return (
         typeof component === 'function' &&
         String(component).includes('createElement')
@@ -13,6 +15,7 @@ export function isInlineFunctionComponent(component) {
 }
 
 export function isFunctionComponent(component) {
+    console.log('isFunctionComponent >>', typeof component)
     return (
         typeof component === 'export function' &&
         String(component).includes('return React.createElement')

--- a/packages/ui-compose/src/validate/index.jsx
+++ b/packages/ui-compose/src/validate/index.jsx
@@ -1,20 +1,20 @@
 export function isClassComponent(component) {
     return (
-        typeof component === 'export function' && 
+        typeof component === 'function' &&
         !!component.prototype.isReactComponent
     ) ? true : false
 }
 
 export function isFunctionComponent(component) {
     return (
-        typeof component === 'export function' && 
+        typeof component === 'function' &&
         String(component).includes('return React.createElement')
     ) ? true : false;
 }
 
 export function isReactComponent(component) {
     return (
-        isClassComponent(component) || 
+        isClassComponent(component) ||
         isFunctionComponent(component)
     ) ? true : false;
 }
@@ -28,7 +28,7 @@ export function isDOMTypeElement(element) {
 }
 
 export function isCompositeTypeElement(element) {
-    return isElement(element) && typeof element.type === 'export function';
+    return isElement(element) && typeof element.type === 'function';
 }
 
 export function isString(element) {


### PR DESCRIPTION
Before:
```
Compiled with warnings.

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/design-system-organisms/src/ToastOpen/index.jsx
  Line 10:6:  React Hook useEffect has missing dependencies: 'closeOnClick', 'closeTimer', 'content', 'id', 'label', 'portal', and 'sx'. Either include them or remove the dependency array                                                                                    react-hooks/exhaustive-deps
  Line 14:6:  React Hook useEffect was passed a dependency list that is not an array literal. This means we can't statically verify whether you've passed the correct dependencies                                                                                             react-hooks/exhaustive-deps
  Line 14:6:  React Hook useEffect has a missing dependency: 'props.open'. Either include it or remove the dependency array. If 'setOpen' needs the current value of 'props.open', you can also switch to useReducer instead of useState and read 'props.open' in the reducer  react-hooks/exhaustive-deps

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/design-system-molecules/src/Card/MainShowcase.jsx
  Line 12:19:  'setSXTitle' is assigned a value but never used    no-unused-vars
  Line 16:21:  'setSXTagline' is assigned a value but never used  no-unused-vars
  Line 23:21:  'setSXContent' is assigned a value but never used  no-unused-vars
  Line 26:21:  'setSXSummary' is assigned a value but never used  no-unused-vars

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/design-system-atoms/src/Box.jsx
  Line 17:6:  React Hook useEffect has a missing dependency: 'theme.gradients'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/react-portal-system/src/reducer.js
  Line 18:11:  Unreachable code  no-unreachable

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/design-system-molecules/src/Card/index.jsx
  Line 18:14:  'setSX' is assigned a value but never used  no-unused-vars

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/design-system-organisms/src/Paginator/index.jsx
  Line 2:8:    'PaginatorHooked' is defined but never used                                                                     no-unused-vars
  Line 5:9:    'pageLimit' is assigned a value but never used                                                                  no-unused-vars
  Line 7:10:   'offset' is assigned a value but never used                                                                     no-unused-vars
  Line 7:18:   'setOffset' is assigned a value but never used                                                                  no-unused-vars
  Line 8:10:   'currentPage' is assigned a value but never used                                                                no-unused-vars
  Line 8:23:   'setCurrentPage' is assigned a value but never used                                                             no-unused-vars
  Line 10:23:  'setCurrentData' is assigned a value but never used                                                             no-unused-vars
  Line 13:8:   Expected a conditional expression and instead saw an assignment                                                 no-cond-assign
  Line 18:6:   React Hook useEffect has a missing dependency: 'data.length'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/react-portal-system/src/components/PortalTypes.jsx
  Line 31:20:  Expected '===' and instead saw '=='  eqeqeq
  Line 38:42:  No duplicate props allowed           react/jsx-no-duplicate-props
  Line 52:20:  Expected '===' and instead saw '=='  eqeqeq
  Line 59:42:  No duplicate props allowed           react/jsx-no-duplicate-props
  Line 81:40:  No duplicate props allowed           react/jsx-no-duplicate-props

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/3box-ui-system/src/components/BoxLoginButton.jsx
  Line 34:42:  Using target="_blank" without rel="noopener noreferrer" is a security risk: see https://mathiasbynens.github.io/rel-noopener  react/jsx-no-target-blank

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/3box-ui-profiles/src/components/ProfileCardVanity.jsx
  Line 38:5:  Duplicate key 'color'  no-dupe-keys

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/3box-ui-profiles/src/components/ProfileCardShowcase.jsx
  Line 39:5:  Duplicate key 'color'  no-dupe-keys

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/3box-ui-system/src/api/component.jsx
  Line 3:30:   Invalid typeof comparison value  valid-typeof
  Line 10:30:  Invalid typeof comparison value  valid-typeof
  Line 31:58:  Invalid typeof comparison value  valid-typeof

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/ui-compose/src/validate/index.jsx
  Line 3:30:   Invalid typeof comparison value  valid-typeof
  Line 10:30:  Invalid typeof comparison value  valid-typeof
  Line 31:58:  Invalid typeof comparison value  valid-typeof

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/ui-compose/src/Component/index.jsx
  Line 3:30:   Invalid typeof comparison value  valid-typeof
  Line 17:30:  Invalid typeof comparison value  valid-typeof
  Line 39:58:  Invalid typeof comparison value  valid-typeof

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/design-system-molecules/src/Showcase/index.jsx
  Line 3:85:  'Span' is defined but never used  no-unused-vars

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/3box-ui-system/src/components/BoxProfileRetrieve.jsx
  Line 44:48:  No duplicate props allowed  react/jsx-no-duplicate-props

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/react-portal-system/src/components/styled/Panel.jsx
  Line 47:42:  No duplicate props allowed  react/jsx-no-duplicate-props

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/3box-ui-system/src/api/ProfileSmall.jsx
  Line 47:48:  No duplicate props allowed  react/jsx-no-duplicate-props

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/3box-ui-state/src/reducer.js
  Line 60:22:  Expected '===' and instead saw '=='  eqeqeq

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/design-system-molecules/src/Slides.jsx
  Line 63:6:  React Hook useEffect has missing dependencies: 'setHeight' and 'setWidth'. Either include them or remove the dependency array. If 'setHeight' changes too often, find the parent component that defines it and wrap that definition in useCallback  react-hooks/exhaustive-deps

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/3box-ui-state/src/requests/useThreadPost.js
  Line 67:11:  Duplicate key 'threadName'  no-dupe-keys

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/react-portal-system/src/components/styled/Modal.jsx
  Line 74:40:  No duplicate props allowed  react/jsx-no-duplicate-props

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/design-system-molecules/src/Card/HeaderShowcase.jsx
  Line 7:10:  'Blockquote' is defined but never used          no-unused-vars
  Line 7:22:  'Container' is defined but never used           no-unused-vars
  Line 7:33:  'BackgroundGradient' is defined but never used  no-unused-vars
  Line 7:70:  'Flex' is defined but never used                no-unused-vars
  Line 7:76:  'Heading' is defined but never used             no-unused-vars
  Line 7:85:  'Span' is defined but never used                no-unused-vars

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/design-system-molecules/src/Card/HeaderDefault.jsx
  Line 7:10:  'Blockquote' is defined but never used          no-unused-vars
  Line 7:22:  'Container' is defined but never used           no-unused-vars
  Line 7:33:  'BackgroundGradient' is defined but never used  no-unused-vars
  Line 7:76:  'Heading' is defined but never used             no-unused-vars
  Line 7:85:  'Span' is defined but never used                no-unused-vars

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/design-system-molecules/src/Card/MainDefault.jsx
  Line 7:8:    'PropTypes' is defined but never used              no-unused-vars
  Line 14:19:  'setSXTitle' is assigned a value but never used    no-unused-vars
  Line 15:21:  'setSXTagline' is assigned a value but never used  no-unused-vars
  Line 19:21:  'setSXContent' is assigned a value but never used  no-unused-vars
  Line 20:21:  'setSXSummary' is assigned a value but never used  no-unused-vars

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/design-system-molecules/src/Card/effects.jsx
  Line 7:8:   'PropTypes' is defined but never used     no-unused-vars
  Line 15:8:  'MainShowcase' is defined but never used  no-unused-vars

/Users/paws/projects/+ConsenSys/rapid-adventures/packages/design-system-molecules/src/Link/index.jsx
  Line 8:9:   'size' is assigned a value but never used    no-unused-vars
  Line 9:9:   'weight' is assigned a value but never used  no-unused-vars
  Line 10:9:  'tag' is assigned a value but never used     no-unused-vars
```


After:
```
Compiled successfully!

You can now view rapid-adventures-site in the browser.

  Local:            http://localhost:3000/
  On Your Network:  http://192.168.178.23:3000/

Note that the development build is not optimized.
To create a production build, use npm run build.
```