### PR TITLE
If user doesnt have metamask installed, dont blow up

### DIFF
--- a/packages/ethers-react-system/src/reducer.js
+++ b/packages/ethers-react-system/src/reducer.js
@@ -115,6 +115,11 @@ const reducerActions = (state, action) => {
         ...state,
         injected: payload
       };
+    case WALLET_PROVIDER_GET_FAILURE:
+      return {
+        ...state,
+        wallet: false
+      };
     case SET_WALLET:
       return {
         ...state


### PR DESCRIPTION
I noticed when testing out onboarding with a _non_ Metamask enabled browser, it appears we dispatch an action that doesn't have a handler, so the default case catches it and at least at the time of writing, causes the whole app to blow up. 

Thought it'd be nice to not blow up :) so that's what this PR aims to accomplish.