### PR TITLE
first pass at context

### DIFF
--- a/apps/dapp/src/DataContext.js
+++ b/apps/dapp/src/DataContext.js
@@ -1,0 +1,28 @@
+import React, { useContext, useReducer } from 'react';
+import adventureList from './data/adventureList.json'
+import questList from './data/questList.json'
+
+const DataContext = React.createContext({
+  adventures: adventureList,
+  quests: questList
+});
+
+const reducer = (state, action) => {
+  switch (action.type) {
+    case 'INIT': {
+      return { ...state }
+    }
+  }
+}
+export default DataContext
+
+export const DataProvider = ({ children }) => {
+  const initialState = useContext(DataContext);
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <DataContext.Provider value={{ state, dispatch }}>
+      {children}
+    </DataContext.Provider>
+  )
+}

--- a/apps/dapp/src/pages/MUI/Adventures.jsx
+++ b/apps/dapp/src/pages/MUI/Adventures.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useContext } from 'react';
 import { useHistory } from 'react-router';
 import { fade, makeStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
@@ -6,7 +6,7 @@ import { Typography, Button, AppBar, Toolbar, InputBase } from '@material-ui/cor
 import SearchIcon from '@material-ui/icons/Search';
 import AddCircleIcon from '@material-ui/icons/AddCircle';
 import rapidLogo from '../../assets/rapid.svg'
-
+import DataContext from '../../DataContext'
 import adventures from 'data/adventureList.json';
 
 const useStyles = makeStyles(theme => ({
@@ -124,6 +124,8 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const AdventuresPage = () => {
+  const data = useContext(DataContext);
+  console.log('data', data);
   const history = useHistory();
   const classes = useStyles();
   const [selectedAdventureId, selectAdventure] = useState()

--- a/apps/dapp/src/providers.jsx
+++ b/apps/dapp/src/providers.jsx
@@ -4,6 +4,7 @@ import { MuiThemeProvider } from '@material-ui/core/styles';
 import { BoxProvider } from '3box-ui-system';
 import { EthersProvider } from 'ethers-react-system';
 import { PortalProvider, PortalTree } from 'react-portal-system';
+import { DataProvider } from './DataContext';
 
 /* --- Local --- */
 import theme from './assets/theme';
@@ -17,12 +18,14 @@ export default props => {
     <ThemeProvider theme={theme}>
       <MuiThemeProvider theme={muiTheme}>
         <EthersProvider>
-          <BoxProvider config={BoxConfig}>
-            <PortalProvider>
-              <PortalTree />
-              {props.children}
-            </PortalProvider>
-          </BoxProvider>
+          <DataProvider>
+            <BoxProvider config={BoxConfig}>
+              <PortalProvider>
+                <PortalTree />
+                {props.children}
+              </PortalProvider>
+            </BoxProvider>
+          </DataProvider>
         </EthersProvider>
       </MuiThemeProvider>
     </ThemeProvider >


### PR DESCRIPTION
Using `useContext` & `useReducer` we have a basic context for the adventure and quest data.
Currently has a solitary reducer in there (pure) called `INIT`.

Not sure if reducers should be considered "in scope" on this but for consistency's sake with the other Providers threw it in there.